### PR TITLE
JPERF-1148: Add iam:AttachRolePolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 - Add `Aws.callerIdentity`.
 - Document required IAM policy in `resources/iam-policy.json`.
 
+### Fixed
+- Make our implementations of `AmiTiebreaker` predictable even when AMI creation dates are equal. Fix [JPERF-1153].
+
+[JPERF-1153]: https://ecosystem.atlassian.net/browse/JPERF-1153
+
 ## [1.11.2] - 2023-03-07
 [1.11.2]: https://bitbucket.org/atlassian/aws-resources/branches/compare/release-1.11.2%0Drelease-1.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Added
 - Add `Aws.sts`.
 - Add `Aws.callerIdentity`.
+- Document required IAM policy in `resources/iam-policy.json`.
 
 ## [1.11.2] - 2023-03-07
 [1.11.2]: https://bitbucket.org/atlassian/aws-resources/branches/compare/release-1.11.2%0Drelease-1.11.1

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/tiebreaker/NewestAvailableAmi.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/tiebreaker/NewestAvailableAmi.kt
@@ -8,7 +8,7 @@ class NewestAvailableAmi : AmiTiebreaker {
         return amis
             .asSequence()
             .filter { ImageState.fromValue(it.state) == ImageState.Available }
-            .sortedByDescending { it.creationDate }
+            .sortedByDescending { it.creationDate + it.imageId }
             .firstOrNull()
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/tiebreaker/NewestPendingAmi.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/tiebreaker/NewestPendingAmi.kt
@@ -10,7 +10,7 @@ class NewestPendingAmi : AmiTiebreaker {
         return amis
             .asSequence()
             .filter { ImageState.fromValue(it.state) in listOf(Available, Pending) }
-            .sortedByDescending { it.creationDate }
+            .sortedByDescending { it.creationDate + it.imageId }
             .firstOrNull()
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/tiebreaker/OldestAvailableAmi.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/tiebreaker/OldestAvailableAmi.kt
@@ -8,7 +8,7 @@ class OldestAvailableAmi : AmiTiebreaker {
         return amis
             .asSequence()
             .filter { ImageState.fromValue(it.state) == ImageState.Available }
-            .sortedBy { it.creationDate }
+            .sortedBy { it.creationDate + it.imageId }
             .firstOrNull()
     }
 }

--- a/src/main/resources/iam-policy.json
+++ b/src/main/resources/iam-policy.json
@@ -29,6 +29,7 @@
         "ec2:RevokeSecurityGroupIngress",
         "ec2:TerminateInstances",
         "iam:AddRoleToInstanceProfile",
+        "iam:AttachRolePolicy",
         "iam:CreateInstanceProfile",
         "iam:CreateRole",
         "iam:DeleteInstanceProfile",


### PR DESCRIPTION
It was needed by `aws#shortTermStorageAccess()`, which was detected by `AwsIT#shouldAttachManagedPolicyArnsToShortTermStorage()`