### PR TITLE
JPERF-1216: Increase cleanup time for `Ec2Instance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Fixed
 - Print EC2 instance ID in "failed to release itself" error message. 
+- Increase cleanup timeout for `Ec2Instance`. Fix [JPERF-1216].
+
+[JPERF-1216]: https://ecosystem.atlassian.net/browse/JPERF-1216
 
 ## [1.12.0] - 2023-06-06
 [1.12.0]: https://github.com/atlassian-labs/aws-resources/compare/release-1.11.2...release-1.12.0

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/housekeeping/ConcurrentHousekeeping.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/housekeeping/ConcurrentHousekeeping.kt
@@ -63,7 +63,7 @@ class ConcurrentHousekeeping(
 
     class Builder {
         private var stackTimeout: Duration = Duration.ofMinutes(5)
-        private var instanceTimeout: Duration = Duration.ofMinutes(2)
+        private var instanceTimeout: Duration = Duration.ofMinutes(4)
         private var amiTimeout: Duration = Duration.ofMinutes(2)
 
         fun stackTimeout(stackTimeout: Duration) = apply { this.stackTimeout = stackTimeout }


### PR DESCRIPTION
We've seen that the cleanup times out very frequently

```
19-Jul-2023 03:02:00	03:02:00,143 INFO  {PRODUCTION_PREFERRED_FRANKFURT} Cleaning expired resources...
19-Jul-2023 03:02:54	03:02:54,409 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@6a8ae86d failed to release itself
19-Jul-2023 03:02:54	03:02:54,411 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@267713d2 failed to release itself
19-Jul-2023 03:02:54	03:02:54,412 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@355ddea0 failed to release itself
19-Jul-2023 03:02:54	03:02:54,413 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@fb32e32 failed to release itself
19-Jul-2023 03:03:09	03:03:09,030 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@1b8167a1 failed to release itself
19-Jul-2023 03:03:09	03:03:09,031 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@e5a98 failed to release itself
19-Jul-2023 03:03:09	03:03:09,031 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@322ae1ae failed to release itself
19-Jul-2023 03:03:09	03:03:09,031 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@7cc6b68b failed to release itself
19-Jul-2023 03:03:09	03:03:09,031 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@6c6a7add failed to release itself
19-Jul-2023 03:03:23	03:03:23,937 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@7b8092a5 failed to release itself
19-Jul-2023 03:03:23	03:03:23,937 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@323b11b0 failed to release itself
19-Jul-2023 03:03:23	03:03:23,938 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@d3839b8 failed to release itself
19-Jul-2023 03:03:23	03:03:23,939 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@24fe7fa failed to release itself
19-Jul-2023 03:03:38	03:03:38,763 ERROR {} com.atlassian.performance.tools.aws.Ec2Instance@17f97039 failed to release itself
19-Jul-2023 03:04:10
19-Jul-2023 03:04:10	Exception in thread "main" java.util.concurrent.TimeoutException
19-Jul-2023 03:04:10	> Task :aws-client:awsClean FAILED
19-Jul-2023 03:04:10	        at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1886)
19-Jul-2023 03:04:10	        at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2021)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.concurrency.api.GracefulTerminationKt.finishBy(GracefulTermination.kt:22)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.aws.api.housekeeping.ConcurrentHousekeeping.waitUntilReleased(ConcurrentHousekeeping.kt:48)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.aws.api.housekeeping.ConcurrentHousekeeping.cleanLeftovers(ConcurrentHousekeeping.kt:24)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.aws.api.Aws.cleanLeftovers(Aws.kt:295)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.aws.client.command.CleanExpired.perform(CleanExpired.kt:16)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.aws.client.command.CleanExpiredKt.main(CleanExpired.kt:24)
19-Jul-2023 03:04:10	        at com.atlassian.performance.tools.aws.client.command.CleanExpiredKt.main(CleanExpired.kt)
```

Checking CloudTrail events revealed that the operation gives up too early.

We believe that increasing the timeout will help. If not we will dig deeper.