### PR TITLE
Add permissions for managing s3 bucket policies and lifecycle configurations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.13.0...master
 
+### Added
+- Add permissions for managing s3 bucket policies and lifecycle configurations.
+
 ### Fixed
 - Add missing `iam:GetRole` permission. You have to update the policy manually. Fix [JPERF-1407].
 

--- a/src/main/resources/iam-policy.json
+++ b/src/main/resources/iam-policy.json
@@ -49,6 +49,10 @@
         "s3:GetObject",
         "s3:ListBucket",
         "s3:PutObject",
+        "s3:GetBucketPolicy",
+        "s3:PutBucketPolicy",
+        "s3:DeleteBucketPolicy",
+        "s3:PutLifecycleConfiguration",
         "sts:GetCallerIdentity",
         "support:CreateCase"
       ],


### PR DESCRIPTION
The code in [this PR](https://github.com/atlassian/aws-infrastructure/pull/166#issuecomment-1771899236) into aws-infrastructure which adds parameters to DataCenterFormula to store avatar and/or attachment data in an S3 bucket (instead of the shared home) requires that the `JPT-dev` role gets these extra permissions to allow attaching a policy to a bucket and to create a lifecycle rule to automatically clean the bucket contents.