### PR TITLE
Tag security groups atomically when created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.14.0...master
 
+### Fixed
+- Tag security groups atomically when created.
+
 ## [1.14.0] - 2024-01-04
 [1.14.0]: https://github.com/atlassian-labs/aws-resources/compare/release-1.13.0...release-1.14.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/AwaitingEc2.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/AwaitingEc2.kt
@@ -98,13 +98,10 @@ class AwaitingEc2(
         investment: Investment,
         request: CreateSecurityGroupRequest
     ): SecurityGroup {
-        val securityGroup = allocateSecurityGroup(request)
-        ec2.createTags(
-            CreateTagsRequest()
-                .withTags(investment.tag().map { it.toEc2() })
-                .withResources(securityGroup.groupId)
-        )
-        return securityGroup
+        val tagSpec = TagSpecification()
+            .withTags(investment.tag().map { it.toEc2() })
+            .withResourceType(ResourceType.SecurityGroup)
+        return allocateSecurityGroup(request.withTagSpecifications(tagSpec))
     }
 
     private fun allocateSecurityGroup(


### PR DESCRIPTION
We had `Ec2SshAccess` security groups, which were not tagged. I suspect that the `CreateTags` request might fail after the security group is created. E.g. the process is killed or the request is throttled.