### PR TITLE
Permit S3 tagging for CloudFormation

### DIFF
--- a/src/main/resources/iam-policy.json
+++ b/src/main/resources/iam-policy.json
@@ -43,6 +43,7 @@
         "iam:PassRole",
         "iam:PutRolePolicy",
         "iam:RemoveRoleFromInstanceProfile",
+        "iam:TagRole",
         "s3:CreateBucket",
         "s3:DeleteBucket",
         "s3:DeleteObject",

--- a/src/main/resources/iam-policy.json
+++ b/src/main/resources/iam-policy.json
@@ -48,6 +48,7 @@
         "s3:DeleteObject",
         "s3:GetObject",
         "s3:ListBucket",
+        "s3:PutBucketTagging",
         "s3:PutObject",
         "s3:GetBucketPolicy",
         "s3:PutBucketPolicy",


### PR DESCRIPTION
Avoid errors like this:
```
Resource handler returned message: "Encountered a permissions error performing a tagging operation, please add required tag permissions.
See https://repost.aws/knowledge-center/cloudformation-tagging-permission-error for how to resolve.
Resource handler returned message: "Access Denied (Service: S3, Status Code: 403, Request ID: GDYGC3TFW6806N9H, Extended Request ID: ...)"" (RequestToken: ..., HandlerErrorCode: UnauthorizedTaggingOperation)
```