### PR TITLE
DCPERF-747 Fix binary incompatibility of `Investment.copy` with the previous minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.17.0...master
+[Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.0...master
+
+## [1.18.0] - 2024-11-29
+[1.18.0]: https://github.com/atlassian-labs/aws-resources/compare/release-1.17.0...release-1.18.0
 
 ### Added
 - Add `Investment.Builder`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.0...master
 
+### Fixed
+- Fix binary incompatibility of `Investment.copy` with the previous minor version.
+
 ## [1.18.0] - 2024-11-29
 [1.18.0]: https://github.com/atlassian-labs/aws-resources/compare/release-1.17.0...release-1.18.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/Investment.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/Investment.kt
@@ -51,6 +51,24 @@ private constructor(
     fun tag(): List<Tag> = tagAtlassianAwsAccountability() + tagLifecycle() + tagInitiator()
 
     /**
+     * Added for backwards compatibility.
+     * TODO: To be removed in the next major version.
+     */
+    fun copy(
+        useCase: String = this.useCase,
+        lifespan: Duration = this.lifespan,
+        disposable: Boolean = this.disposable,
+        reuseKey: () -> String = this.reuseKey
+    ): Investment {
+        return Investment(
+            useCase = useCase,
+            lifespan = lifespan,
+            disposable = disposable,
+            reuseKey = reuseKey
+        )
+    }
+
+    /**
      * @return tags required by all Atlassian AWS accounts
      */
     private fun tagAtlassianAwsAccountability(): List<Tag> = listOf(


### PR DESCRIPTION
The `Investment.copy` method needs to be overriden for backwards compatibility with the previous minor version.

More information: https://kotlinlang.org/docs/api-guidelines-backward-compatibility.html#avoid-using-data-classes-in-your-api