### PR TITLE
DCPERF-949 bump ubuntu focal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,15 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      # This step is a workaround to avoid a decryption issue caused by mark-vieira/gradle-maven-settings-plugin
+      # See https://github.com/mark-vieira/gradle-maven-settings-plugin/issues/15 for details
+      - name: Remove default github maven configuration
+        run: rm ~/.m2/settings.xml
       - name: Auth AWS
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,14 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.1...master
+[Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.2...master
+
+## [1.18.2] - 2025-06-03
+[1.18.2]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.1...release-1.18.2
+
+### Fixed
+- Bump Ubuntu Focal AMI to `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250508.1`.
+  The previous one was over a year old and disappeared: `ubuntu-focal-20.04-amd64-server-20240531`.
 
 ## [1.18.1] - 2024-12-03
 [1.18.1]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.0...release-1.18.1

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/CanonicalAmiProvider.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/CanonicalAmiProvider.kt
@@ -32,7 +32,7 @@ class CanonicalAmiProvider private constructor(
     }
 
     class Builder {
-        private val focal = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20240531"
+        private val focal = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250508.1"
         private var imageName = focal
 
         /**


### PR DESCRIPTION
Bump Ubuntu Focal AMI to `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250508.1`.
The previous one was over a year old and disappeared: `ubuntu-focal-20.04-amd64-server-20240531`.

This PR also contains a commit to set JDK to 11 as the newer versions currently cause the project to fail to build (see https://github.com/atlassian-labs/aws-resources/actions/runs/15415644545/job/43377675556) 