### PR TITLE
DCPERF-949 Use JDK 11 in the CI in the release step and housekeeping workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
       - name: Auth Maven
         id: publish-token
         uses: atlassian-labs/artifact-publish-token@v1.0.1

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -14,6 +14,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Using JDK 11 was done partially in https://github.com/atlassian-labs/aws-resources/pull/30, but didn't cover all the required places.

To fix the following build errors:
> Task :compileKotlin FAILED
65w: Language version 1.2 is deprecated and its support will be removed in a future version of Kotlin 66e: java.lang.ExceptionInInitializerError
67	at org.jetbrains.kotlin.com.intellij.pom.java.LanguageLevel.<clinit>(LanguageLevel.java:25) 68	at org.jetbrains.kotlin.com.intellij.core.CoreLanguageLevelProjectExtension.<init>(CoreLanguageLevelProjectExtension.java:26) 69	at org.jetbrains.kotlin.com.intellij.core.JavaCoreProjectEnvironment.<init>(JavaCoreProjectEnvironment.java:42) 70	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreProjectEnvironment.<init>(KotlinCoreProjectEnvironment.kt:26) 71	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$ProjectEnvironment.<init>(KotlinCoreEnvironment.kt:121) 72	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.createForProduction(KotlinCoreEnvironment.kt:425) 73	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.createCoreEnvironment(K2JVMCompiler.kt:226) 74	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:152) 75	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:52) 76	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:88) 77	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:44) 78	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:98) 79	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:386) 80	at org.jetbrains.kotlin.incremental.IncrementalJvmCompilerRunner.runCompiler(IncrementalJvmCompilerRunner.kt:110) 81	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileIncrementally(IncrementalCompilerRunner.kt:286) 82	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl$rebuild(IncrementalCompilerRunner.kt:99) 83	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compileImpl(IncrementalCompilerRunner.kt:114) 84	at org.jetbrains.kotlin.incremental.IncrementalCompilerRunner.compile(IncrementalCompilerRunner.kt:74) 85	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.execIncrementalCompiler(CompileServiceImpl.kt:607) 86	at org.jetbrains.kotlin.daemon.CompileServiceImplBase.access$execIncrementalCompiler(CompileServiceImpl.kt:96) 87	at org.jetbrains.kotlin.daemon.CompileServiceImpl.compile(CompileServiceImpl.kt:1659) 88	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) 89	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) 90	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) 91	at java.base/java.lang.reflect.Method.invoke(Method.java:569) 92	at java.rmi/sun.rmi.server.UnicastServerRef.dispatch(UnicastServerRef.java:360) 93	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:200) 94	at java.rmi/sun.rmi.transport.Transport$1.run(Transport.java:197) 95	at java.base/java.security.AccessController.doPrivileged(AccessController.java:712) 96	at java.rmi/sun.rmi.transport.Transport.serviceCall(Transport.java:196) 97	at java.rmi/sun.rmi.transport.tcp.TCPTransport.handleMessages(TCPTransport.java:587) 98	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run0(TCPTransport.java:828) 99	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.lambda$run$0(TCPTransport.java:705) 100	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399) 101	at java.rmi/sun.rmi.transport.tcp.TCPTransport$ConnectionHandler.run(TCPTransport.java:704) 102	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) 103	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) 104	at java.base/java.lang.Thread.run(Thread.java:840) 105Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected void java.util.ResourceBundle.setParent(java.util.ResourceBundle) accessible: module java.base does not "opens java.util" to unnamed module @6a463b3d 106	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354) 107	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297) 108	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:200) 109	at java.base/java.lang.reflect.Method.setAccessible(Method.java:194) 110	at org.jetbrains.kotlin.com.intellij.util.ReflectionUtil.makeAccessible(ReflectionUtil.java:252) 111	at org.jetbrains.kotlin.com.intellij.util.ReflectionUtil.getDeclaredMethod(ReflectionUtil.java:269) 112	at org.jetbrains.kotlin.com.intellij.DynamicBundle.<clinit>(DynamicBundle.java:22) 113	... 38 more