### PR TITLE
DCPERF-949 Provide a workaround in housekeeping CI around a decryption issue

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
+      # This step is a workaround to avoid a decryption issue caused by mark-vieira/gradle-maven-settings-plugin
+      # See https://github.com/mark-vieira/gradle-maven-settings-plugin/issues/15 for details
+      - name: Remove default github maven configuration
+        run: rm ~/.m2/settings.xml
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:


### PR DESCRIPTION
Similar workaround was added in build CI in https://github.com/atlassian-labs/aws-resources/pull/30

This stops the CI from failing with the following error: FAILURE: Build failed with an exception.

* Where:
Build file '/home/runner/work/aws-resources/aws-resources/build.gradle.kts' line: 5

* What went wrong: An exception occurred applying plugin request [id: 'com.atlassian.performance.tools.gradle-release', version: '0.8.0']
> Failed to apply plugin 'com.atlassian.performance.tools.gradle-release'.
   > Unable to decrypt local Maven settings credentials.