### PR TITLE
DCPERF-975 Bump Ubuntu Focal AMI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,14 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.3...master
+[Unreleased]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.4...master
+
+## [1.18.4] - 2025-06-16
+[1.18.4]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.3...release-1.18.4
+
+### Fixed
+- Bump Ubuntu Focal AMI to `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250603`.
+  The previous one was not that old, but still disappeared: `ubuntu-focal-20.04-amd64-server-20250508.1`.
 
 ## [1.18.3] - 2025-06-04
 [1.18.3]: https://github.com/atlassian-labs/aws-resources/compare/release-1.18.2...release-1.18.3

--- a/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/CanonicalAmiProvider.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/aws/api/ami/CanonicalAmiProvider.kt
@@ -32,7 +32,7 @@ class CanonicalAmiProvider private constructor(
     }
 
     class Builder {
-        private val focal = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250508.1"
+        private val focal = "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250603"
         private var imageName = focal
 
         /**


### PR DESCRIPTION
Bump Ubuntu Focal AMI to `ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20250603`. The previous one was not that old, but still disappeared: `ubuntu-focal-20.04-amd64-server-20250508.1`.

Mark 1.18.4